### PR TITLE
refactor game status 

### DIFF
--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
@@ -63,7 +63,7 @@ public class GameController {
         if (status != null) {
             spec = spec.and(GameSpecification.equalStatus(status));
         } else {
-            spec = spec.and(GameSpecification.notEqualStatus());
+            spec = spec.and(GameSpecification.notDelete());
         }
 
         return gameService.findAll(spec, pageable).map(game -> new ResponseGameDTO(game));

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
@@ -51,17 +51,20 @@ public class GameController {
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDt,
             @PageableDefault(sort = "regDtm", direction = Sort.Direction.DESC) Pageable pageable) {
 
-
         Specification<Game> spec = (root, query, criteriaBuilder) -> null;
         if (courtNo != null) spec = spec.and(GameSpecification.equalCourtNo(courtNo));
         if (uid != null) spec = spec.and(GameSpecification.equalUid(uid));
         if (genderType != null) spec = spec.and(GameSpecification.equalGenderType(genderType));
         if (ageType != null) spec = spec.and(GameSpecification.equalAgeType(ageType));
         if (historyType != null) spec = spec.and(GameSpecification.equalHistoryType(historyType));
-        if (status != null) spec = spec.and(GameSpecification.equalStatus(status));
         if (strDt != null) spec = spec.and(GameSpecification.geStrDt(strDt));
         if (endDt != null) spec = spec.and(GameSpecification.leEndDt(endDt));
         if (score != null) spec = spec.and(GameSpecification.geScore(score));
+        if (status != null) {
+            spec = spec.and(GameSpecification.equalStatus(status));
+        } else {
+            spec = spec.and(GameSpecification.notEqualStatus());
+        }
 
         return gameService.findAll(spec, pageable).map(game -> new ResponseGameDTO(game));
     }

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
@@ -5,6 +5,7 @@ import kr.couchcoding.tennis_together.controller.game.dto.ResponseGameDTO;
 import kr.couchcoding.tennis_together.controller.game.specification.GameSpecification;
 import kr.couchcoding.tennis_together.domain.game.model.Game;
 import kr.couchcoding.tennis_together.domain.game.service.GameService;
+import kr.couchcoding.tennis_together.domain.game.status.GameStatus;
 import kr.couchcoding.tennis_together.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -45,10 +46,11 @@ public class GameController {
             @RequestParam(required = false) String genderType,
             @RequestParam(required = false) Integer ageType,
             @RequestParam(required = false) Integer historyType,
-            @RequestParam(required = false) Character status,
+            @RequestParam(required = false) GameStatus status,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate strDt,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDt,
             @PageableDefault(sort = "regDtm", direction = Sort.Direction.DESC) Pageable pageable) {
+
 
         Specification<Game> spec = (root, query, criteriaBuilder) -> null;
         if (courtNo != null) spec = spec.and(GameSpecification.equalCourtNo(courtNo));

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
@@ -72,8 +72,6 @@ public class GameController {
     @DeleteMapping("/{gameNo}")
     public void deleteGame(@PathVariable Long gameNo, Authentication authentication) {
         User user = ((User) authentication.getPrincipal());
-        Game game = gameService.findGameByGameNoAndGameCreator(gameNo, user);
-
-        gameService.deleteGame(game);
+        gameService.deleteGame(user, gameNo);
     }
 }

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/GameController.java
@@ -1,10 +1,8 @@
 package kr.couchcoding.tennis_together.controller.game;
 
-import kr.couchcoding.tennis_together.controller.game.dto.PostGameDTO;
+import kr.couchcoding.tennis_together.controller.game.dto.RequestGameDTO;
 import kr.couchcoding.tennis_together.controller.game.dto.ResponseGameDTO;
 import kr.couchcoding.tennis_together.controller.game.specification.GameSpecification;
-import kr.couchcoding.tennis_together.domain.court.model.Court;
-import kr.couchcoding.tennis_together.domain.court.service.CourtService;
 import kr.couchcoding.tennis_together.domain.game.model.Game;
 import kr.couchcoding.tennis_together.domain.game.service.GameService;
 import kr.couchcoding.tennis_together.domain.user.model.User;
@@ -26,30 +24,15 @@ import java.time.LocalDate;
 public class GameController {
 
     private final GameService gameService;
-    private final CourtService courtService;
 
     @PostMapping
-    public void postGame(@RequestBody PostGameDTO postGameDTO, Authentication authentication) {
+    public ResponseGameDTO postGame(@RequestBody RequestGameDTO postGameDTO, Authentication authentication) {
         User user = ((User) authentication.getPrincipal());
-        Court court = courtService.findCourtByNo(postGameDTO.getCourtNo());
-
-        Game game = Game.builder()
-                .gameCreator(user)
-                .court(court)
-                .title(postGameDTO.getTitle())
-                .content(postGameDTO.getContent())
-                .historyType(postGameDTO.getHistoryType())
-                .ageType(postGameDTO.getAgeType())
-                .genderType(postGameDTO.getGenderType())
-                .strDt(postGameDTO.getStrDt())
-                .endDt(postGameDTO.getEndDt())
-                .build();
-
-        gameService.postGame(game);
+        return new ResponseGameDTO(gameService.postGame(user, postGameDTO));
     }
 
     @PatchMapping("/{gameNo}")
-    public void updateGame(@PathVariable Long gameNo, @RequestBody PostGameDTO updatedGameDTO, Authentication authentication) {
+    public void updateGame(@PathVariable Long gameNo, @RequestBody RequestGameDTO updatedGameDTO, Authentication authentication) {
         User user = ((User) authentication.getPrincipal());
         gameService.updateGame(user, gameNo, updatedGameDTO);
     }

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/dto/RequestGameDTO.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/dto/RequestGameDTO.java
@@ -7,7 +7,7 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
-public class PostGameDTO {
+public class RequestGameDTO {
 
     String title;
     String content;

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/dto/ResponseGameDTO.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/dto/ResponseGameDTO.java
@@ -2,6 +2,7 @@ package kr.couchcoding.tennis_together.controller.game.dto;
 
 import kr.couchcoding.tennis_together.domain.court.model.Court;
 import kr.couchcoding.tennis_together.domain.game.model.Game;
+import kr.couchcoding.tennis_together.domain.game.status.GameStatus;
 import kr.couchcoding.tennis_together.domain.user.model.User;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,7 +26,7 @@ public class ResponseGameDTO {
     private LocalDateTime regDtm;
     private LocalDateTime updDtm;
     private Court court;
-    private Character stDvCd;
+    private GameStatus stDvCd;
 
     public ResponseGameDTO(Game game) {
         gameNo = game.getGameNo();
@@ -40,6 +41,6 @@ public class ResponseGameDTO {
         regDtm = game.getRegDtm();
         updDtm = game.getUpdDtm();
         court = game.getCourt();
-        stDvCd = game.getStDvCd();
+        stDvCd = game.getGameStatus();
     }
 }

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/specification/GameSpecification.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/specification/GameSpecification.java
@@ -32,6 +32,10 @@ public class GameSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("gameStatus"), status);
     }
 
+    public static Specification<Game> notEqualStatus() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("gameStatus"), GameStatus.DELETED);
+    }
+
     public static Specification<Game> geStrDt(LocalDate strDt) {
         return (root, query, criteriaBuilder) -> criteriaBuilder.greaterThanOrEqualTo(root.get("strDt"), strDt);
     }

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/specification/GameSpecification.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/specification/GameSpecification.java
@@ -1,6 +1,7 @@
 package kr.couchcoding.tennis_together.controller.game.specification;
 
 import kr.couchcoding.tennis_together.domain.game.model.Game;
+import kr.couchcoding.tennis_together.domain.game.status.GameStatus;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
@@ -27,8 +28,8 @@ public class GameSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("historyType"), historyType);
     }
 
-    public static Specification<Game> equalStatus(char status) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("stDvCd"), status);
+    public static Specification<Game> equalStatus(GameStatus status) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("gameStatus"), status);
     }
 
     public static Specification<Game> geStrDt(LocalDate strDt) {

--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/specification/GameSpecification.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/specification/GameSpecification.java
@@ -32,7 +32,7 @@ public class GameSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("gameStatus"), status);
     }
 
-    public static Specification<Game> notEqualStatus() {
+    public static Specification<Game> notDelete() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("gameStatus"), GameStatus.DELETED);
     }
 

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/model/Game.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/model/Game.java
@@ -1,6 +1,7 @@
 package kr.couchcoding.tennis_together.domain.game.model;
 
 import kr.couchcoding.tennis_together.domain.court.model.Court;
+import kr.couchcoding.tennis_together.domain.game.status.GameStatus;
 import kr.couchcoding.tennis_together.domain.user.model.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -63,11 +64,13 @@ public class Game {
     private Court court;
 
     @Column(name = "st_dv_cd")
-    private Character stDvCd = '1';
+    @Enumerated(EnumType.ORDINAL)
+    private GameStatus gameStatus;
 
     @Builder
     public Game(long gameNo, User gameCreator, String title, String content, String genderType,
-                Integer historyType, Integer ageType, LocalDate strDt, LocalDate endDt, Court court) {
+                Integer historyType, Integer ageType, LocalDate strDt, LocalDate endDt, Court court,
+                GameStatus gameStatus) {
         this.gameNo = gameNo;
         this.gameCreator = gameCreator;
         this.title = title;
@@ -78,6 +81,7 @@ public class Game {
         this.strDt = strDt;
         this.endDt = endDt;
         this.court = court;
+        this.gameStatus = gameStatus;
     }
 
     public void updateGame(Game updatedGame) {

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/model/Game.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/model/Game.java
@@ -64,7 +64,7 @@ public class Game {
     private Court court;
 
     @Column(name = "st_dv_cd")
-    @Enumerated(EnumType.ORDINAL)
+    @Enumerated(EnumType.STRING)
     private GameStatus gameStatus;
 
     @Builder

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/model/Game.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/model/Game.java
@@ -94,4 +94,8 @@ public class Game {
         if (updatedGame.getStrDt() != null) strDt = updatedGame.getStrDt();
         if (updatedGame.getEndDt() != null) endDt = updatedGame.getEndDt();
     }
+
+    public void updateStatus(GameStatus gameStatus) {
+        this.gameStatus = gameStatus;
+    }
 }

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameService.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameService.java
@@ -1,11 +1,11 @@
 package kr.couchcoding.tennis_together.domain.game.service;
 
-import kr.couchcoding.tennis_together.controller.game.dto.PostGameDTO;
-import kr.couchcoding.tennis_together.controller.game.dto.ResponseGameDTO;
+import kr.couchcoding.tennis_together.controller.game.dto.RequestGameDTO;
 import kr.couchcoding.tennis_together.domain.court.model.Court;
 import kr.couchcoding.tennis_together.domain.court.service.CourtService;
 import kr.couchcoding.tennis_together.domain.game.dao.GameRepository;
 import kr.couchcoding.tennis_together.domain.game.model.Game;
+import kr.couchcoding.tennis_together.domain.game.status.GameStatus;
 import kr.couchcoding.tennis_together.domain.user.model.User;
 import kr.couchcoding.tennis_together.exception.CustomException;
 import kr.couchcoding.tennis_together.exception.ErrorCode;
@@ -26,8 +26,23 @@ public class GameService {
     private final GameRepository gameRepository;
     private final CourtService courtService;
 
-    public void postGame(Game game) {
-        gameRepository.save(game);
+    public Game postGame(User user, RequestGameDTO postGameDTO) {
+        Court court = courtService.findCourtByNo(postGameDTO.getCourtNo());
+
+        Game game = Game.builder()
+                .gameCreator(user)
+                .court(court)
+                .title(postGameDTO.getTitle())
+                .content(postGameDTO.getContent())
+                .historyType(postGameDTO.getHistoryType())
+                .ageType(postGameDTO.getAgeType())
+                .genderType(postGameDTO.getGenderType())
+                .strDt(postGameDTO.getStrDt())
+                .endDt(postGameDTO.getEndDt())
+                .gameStatus(GameStatus.RECRUITING)
+                .build();
+
+        return gameRepository.save(game);
     }
 
     public Game findGameByGameNoAndGameCreator(Long gameNo, User gameCreator) {
@@ -35,7 +50,7 @@ public class GameService {
         return game.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GAME));
     }
 
-    public void updateGame(User user, Long gameNo, PostGameDTO updatedGameDTO) {
+    public void updateGame(User user, Long gameNo, RequestGameDTO updatedGameDTO) {
         Game game = findGameByGameNoAndGameCreator(gameNo, user);
         Court court = null;
 

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameService.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameService.java
@@ -46,8 +46,18 @@ public class GameService {
     }
 
     public Game findGameByGameNoAndGameCreator(Long gameNo, User gameCreator) {
-        Optional<Game> game = gameRepository.findGameByGameNoAndGameCreator(gameNo, gameCreator);
-        return game.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GAME));
+        Optional<Game> gameOpt = gameRepository.findGameByGameNoAndGameCreator(gameNo, gameCreator);
+
+        gameOpt.ifPresentOrElse(
+                game -> {
+                    if (game.getGameStatus() == GameStatus.DELETED)
+                        throw new CustomException(ErrorCode.BAD_REQUEST_GAME, "삭제된 Game 입니다.");
+                },
+                () -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_GAME);
+                });
+
+        return gameOpt.get();
     }
 
     public void updateGame(User user, Long gameNo, RequestGameDTO updatedGameDTO) {
@@ -90,7 +100,17 @@ public class GameService {
     }
 
     public Game findGameByNo(Long gameNo) {
-        Optional<Game> game = gameRepository.findById(gameNo);
-        return game.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GAME));
+        Optional<Game> gameOpt = gameRepository.findById(gameNo);
+
+        gameOpt.ifPresentOrElse(
+                game -> {
+                    if (game.getGameStatus() == GameStatus.DELETED)
+                        throw new CustomException(ErrorCode.BAD_REQUEST_GAME, "삭제된 Game 입니다.");
+                },
+                () -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_GAME);
+                });
+
+        return gameOpt.get();
     }
 }

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameService.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameService.java
@@ -80,8 +80,13 @@ public class GameService {
         return games;
     }
 
-    public void deleteGame(Game game) {
-        gameRepository.delete(game);
+    public void deleteGame(User user, long gameNo) {
+        Game game = findGameByGameNoAndGameCreator(gameNo, user);
+
+        if (game.getGameStatus() == GameStatus.DELETED)
+            throw new CustomException(ErrorCode.BAD_REQUEST_GAME, "이미 삭제된 게임입니다.");
+
+        game.updateStatus(GameStatus.DELETED);
     }
 
     public Game findGameByNo(Long gameNo) {

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/status/GameStatus.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/status/GameStatus.java
@@ -1,0 +1,8 @@
+package kr.couchcoding.tennis_together.domain.game.status;
+
+public enum GameStatus {
+
+    RECRUITING, // 모집중
+    CLOSED,     // 마감
+    DELETED     // 삭제
+}

--- a/src/main/java/kr/couchcoding/tennis_together/exception/ErrorCode.java
+++ b/src/main/java/kr/couchcoding/tennis_together/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     BAD_REQUEST_PARAM(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    BAD_REQUEST_GAME(HttpStatus.BAD_REQUEST, "잘못된 게임요청입니다."),
 
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "해당 요청은 로그인이 필요합니다."),
     FORBIDDEN_USER(HttpStatus.FORBIDDEN, "해당 요청에 권한이 없습니다."),


### PR DESCRIPTION
Game Entity의 상태 부분을 수정했습니다.

코드 관리 차원에서 Enum으로 상태를 관리하는게 용이해보여 GameStatus라는 Enum 클래스를 만들었습니다.
게임 생성시 GameStatus.RECRUITING이 되고 Game 삭제시 GameStatus.DELETED 상태가 됩니다.
후에 게임 매칭 로직이 구현 된다면 CLOSED 상태가 될 것입니다.

최대한  DB 스펙을 변경 없이 가려고 Enum을 Orgin 타입으로 사용했으나  컨트롤러나 이런저런 타입 불일치가 발생하네요.  Enum 마다 컨버터를 만드는것도 번거로운 일이 될 것같아 DB의 status 타입을 char에서 varchar로 바꾸고, Enum을 String 값을 사용하도록 해봤습니다.

