### PR TITLE
Fix/diff server and korea time

### DIFF
--- a/src/main/java/kr/couchcoding/tennis_together/controller/game/GameUserListController.java
+++ b/src/main/java/kr/couchcoding/tennis_together/controller/game/GameUserListController.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 @RestController
 @RequiredArgsConstructor
@@ -78,7 +79,7 @@ public class GameUserListController {
         spec = spec.or(GameUserListSpecification.equalGameCreator(user.getUid()));
         spec = spec.or(GameUserListSpecification.equalGameUser(user.getUsername()));
         spec = spec.and(GameUserListSpecification.notEqualGameStatus(GameStatus.RECRUITING));
-        spec = spec.and(GameUserListSpecification.lessThanEndDt(LocalDate.now()));
+        spec = spec.and(GameUserListSpecification.lessThanEndDt(LocalDate.now(ZoneId.of("+09:00:00"))));
         spec = spec.and(GameUserListSpecification.equalStatus(GameUserListStatus.APPROVED));
 
         Page<GameUserList> gameUserLists = gameUserListService.findHistoriesPlayedGame(spec, pageable);

--- a/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameUserListService.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/game/service/GameUserListService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +42,7 @@ public class GameUserListService {
     }
 
     private void verifyGameForApply(User user, Game game) {
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneId.of("+09:00:00"));
 
         if (game.getGameStatus() != GameStatus.RECRUITING)
             throw new CustomException(ErrorCode.BAD_REQUEST_GAME, game.getGameStatus() + " 상태의 게임을 신청할 수 없습니다.");
@@ -65,7 +66,7 @@ public class GameUserListService {
         GameUserList gameUserList = gameUserListRepository.findByGameUserAndJoinedGame(user, game)
                 .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_GAME, "해당 게임에 신청한 이력이 없습니다."));
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneId.of("+09:00:00"));
 
         if (game.getStrDt().equals(now) || game.getEndDt().equals(now) ||
                 (game.getStrDt().isBefore(now) && game.getEndDt().isAfter(now))) {
@@ -97,7 +98,7 @@ public class GameUserListService {
         if (game.getGameStatus() != GameStatus.RECRUITING)
             throw new CustomException(ErrorCode.BAD_REQUEST_GAME, game.getGameStatus() + " 상태의 게임의 요청을 승인할 수 없습니다.");
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneId.of("+09:00:00"));
         if (!(game.getStrDt().equals(now) || game.getEndDt().equals(now))
                 && !(game.getStrDt().isBefore(now) && game.getEndDt().isAfter(now)))
             throw new CustomException(ErrorCode.BAD_REQUEST_GAME, "신청기간이 아닙니다.");
@@ -113,7 +114,7 @@ public class GameUserListService {
         GameUserList gameUserList = gameUserListRepository.findByGameUserAndJoinedGame(joinedUser, game)
                 .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_GAME, "해당 유저는 게임에 신청한 이력이 없습니다."));
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneId.of("+09:00:00"));
         if (game.getStrDt().equals(now) || game.getEndDt().equals(now) ||
                 (game.getStrDt().isBefore(now) && game.getEndDt().isAfter(now))) {
             if (gameUserList.getStatus() == GameUserListStatus.APPROVED)

--- a/src/main/java/kr/couchcoding/tennis_together/domain/userreview/service/UserReviewService.java
+++ b/src/main/java/kr/couchcoding/tennis_together/domain/userreview/service/UserReviewService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Optional;
 
 @Service
@@ -49,7 +50,7 @@ public class UserReviewService {
         } else
             throw new CustomException(ErrorCode.FORBIDDEN_USER, "리뷰를 작성할 권한이 없습니다.");
 
-        if (game.getEndDt().isAfter(LocalDate.now()) || game.getGameStatus() != GameStatus.CLOSED)
+        if (game.getEndDt().isAfter(LocalDate.now(ZoneId.of("+09:00:00"))) || game.getGameStatus() != GameStatus.CLOSED)
             throw new CustomException(ErrorCode.BAD_REQUEST_USER_REVIEW, "게임이 끝난 후 리뷰를 등록할 수 있습니다.");
 
         UserReview userReview = UserReview.builder()


### PR DESCRIPTION
해로쿠 서버가 외국에 있어서 LocalDate.now()의 시간이 한국과 맞지 않는 오류를 발견했습니다.

LocalDate.now()을 모두 LocalDate.now(ZoneId.of("+09:00:00"))로 변경해 무조건 한국 시간을 불러오도록 했습니다.
